### PR TITLE
add redisearch configs to docker compose file

### DIFF
--- a/Master/docker-compose.yaml
+++ b/Master/docker-compose.yaml
@@ -9,6 +9,9 @@ services:
     container_name: redis-master
     environment:
       - TZ=Asia/Tehran
+      - REDISEARCH_ARGS=TIMEOUT 5000
+      - REDISEARCH_ARGS=MAXSEARCHRESULTS -1
+      - REDISEARCH_ARGS=CONCURRENT_WRITE_MODE      
     restart: unless-stopped
     mem_limit: 2g
     ports:


### PR DESCRIPTION
I added some `Redisearch` configs to the `docker compose` file.
